### PR TITLE
adds workflow for publishing to github pages

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,45 @@
+# Build project, export static content and push to deployment branch
+
+name: Deploy GitHub Page
+
+on:
+  push:
+    branches: [develop]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+      - name: Get files
+        uses: actions/checkout@v2
+
+      - name: Use Node.js ${{ matrix.node-version }}
+        uses: actions/setup-node@v2
+        with:
+          node-version: ${{ matrix.node-version }}
+
+      - name: Install packages
+        run: npm ci
+
+      - name: Build project
+        run: npm run build
+
+      - name: Run Tests
+        run: npm run test:ci
+
+      - name: Export static files
+        run: npm run export
+
+      - name: Add .nojekyll file
+        run: touch ./out/.nojekyll
+
+      - name: Deploy
+        uses: JamesIves/github-pages-deploy-action@4.1.5
+        with:
+          branch: gh-pages
+          folder: out


### PR DESCRIPTION
Since we disabled the travis ci deployment a while ago, we need a new strategy. I vouch for deploying via github workflow. 
The new workflow will:
1. build the project
2. run the tests
3. export the static site to an `out` directory
4. publish the static content to the `gh-pages` branch

The new branch will serve as our deployment source for the Github Page. 
After this process has been established, we can also move on to using the master/main again as the root branch. 